### PR TITLE
Prep for dancer2 1.0.0

### DIFF
--- a/META.json
+++ b/META.json
@@ -49,7 +49,7 @@
       "test" : {
          "requires" : {
             "Dancer2" : "0",
-            "Dancer2::Test" : "0",
+            "Plack::Test" : "0",
             "ExtUtils::MakeMaker" : "0",
             "File::Find" : "0",
             "File::Spec::Functions" : "0",

--- a/README.pod
+++ b/README.pod
@@ -1,12 +1,14 @@
 =pod
 
+=encoding UTF-8
+
 =head1 NAME
 
 Dancer2::Plugin::Syntax::GetPost - Syntactic sugar for GET+POST handlers
 
 =head1 VERSION
 
-version 0.002
+version 0.003
 
 =head1 SYNOPSIS
 
@@ -37,14 +39,14 @@ L<Dancer2>
 
 =back
 
-=for :stopwords cpan testmatrix url annocpan anno bugtracker rt cpants kwalitee diff irc mailto metadata placeholders metacpan
+=for :stopwords cpan testmatrix url bugtracker rt cpants kwalitee diff irc mailto metadata placeholders metacpan
 
 =head1 SUPPORT
 
 =head2 Bugs / Feature Requests
 
 Please report any bugs or feature requests through the issue tracker
-at L<https://github.com/dagolden/dancer2-plugin-syntax-getpost/issues>.
+at L<https://github.com/PerlDancer/dancer2-plugin-syntax-getpost/issues>.
 You will be notified automatically of any progress on your issue.
 
 =head2 Source Code
@@ -52,9 +54,9 @@ You will be notified automatically of any progress on your issue.
 This is open source software.  The code repository is available for
 public review and contribution under the terms of the license.
 
-L<https://github.com/dagolden/dancer2-plugin-syntax-getpost>
+L<https://github.com/PerlDancer/dancer2-plugin-syntax-getpost>
 
-  git clone git://github.com/dagolden/dancer2-plugin-syntax-getpost.git
+  git clone https://github.com/PerlDancer/dancer2-plugin-syntax-getpost.git
 
 =head1 AUTHOR
 
@@ -62,9 +64,10 @@ David Golden <dagolden@cpan.org>
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is Copyright (c) 2012 by David Golden.
+This software is Copyright (c) 2023 by David Golden.
 
 This is free software, licensed under:
 
   The Apache License, Version 2.0, January 2004
 
+=cut

--- a/dist.ini
+++ b/dist.ini
@@ -2,10 +2,13 @@ name    = Dancer2-Plugin-Syntax-GetPost
 author  = David Golden <dagolden@cpan.org>
 license = Apache_2_0
 copyright_holder = David Golden
-copyright_year   = 2012
+copyright_year   = 2023
 
 [@DAGOLDEN]
 :version = 0.032
+-remove = MetaJSON
+-remove = PodCoverageTests
+-remove = Test::Version
 AutoMetaResources.bugtracker.rt = 0
-AutoMetaResources.bugtracker.github = user:dagolden
+AutoMetaResources.bugtracker.github = user:perldancer
 

--- a/t/getpost.t
+++ b/t/getpost.t
@@ -1,18 +1,32 @@
 use strict;
 use warnings;
 use Test::More 0.96 import => ['!pass'];
+use Plack::Test;
+use HTTP::Request::Common;
 
-use Dancer2;
-use Dancer2::Test;
-use Dancer2::Plugin::Syntax::GetPost;
+{
+    package TestApp;
 
-get_post '/form' => sub { return "method = " . request->method };
+    use Dancer2;
+    use Dancer2::Plugin::Syntax::GetPost;
 
-route_exists [ GET => '/form' ];
-route_exists [ POST => '/form' ];
-route_doesnt_exist [ PUT => '/form' ];
-response_content_like [ GET => '/form' ], qr/method = GET/;
-response_content_like [ POST => '/form' ], qr/method = POST/;
+    get_post '/form' => sub { return "method = " . request->method };
+
+    1;
+}
+
+my $app = Plack::Test->create( TestApp->to_app );
+
+my $res = $app->request( GET '/form' );
+is( $res->code, 200, 'GET /form exists' );
+like( $res->content, qr/method = GET/, 'GET content matches expected output' );
+
+$res = $app->request( POST '/form' );
+is( $res->code, 200, 'POST /form exists' );
+like( $res->content, qr/method = POST/, 'POST content matches expected output' );
+
+$res = $app->request( PUT '/form' );
+is( $res->code, 404, 'PUT /form does not exist' );
 
 done_testing;
 # COPYRIGHT


### PR DESCRIPTION
Replace Dancer2::Test, and fix some packaging problems so we can create an updated version that will install with Dancer2 1.0.0.